### PR TITLE
Include tags when updating fork

### DIFF
--- a/update-fork.ps1
+++ b/update-fork.ps1
@@ -56,7 +56,7 @@ function UpdateFork {
 
     # fetch the changes from the parent
     Write-Host "Fetching changes from parent repo"
-    git fetch github $parent.parentDefaultBranch
+    git fetch github $parent.parentDefaultBranch --tags
 
     # make sure you are on the right branch
     Write-Host "Pulling all changes from the parent on branch [$($parent.parentDefaultBranch)]"
@@ -68,7 +68,7 @@ function UpdateFork {
 
     # push the changes back to your repo
     Write-Host "Pushing changes back to fork"
-    git push
+    git push --tags
 
     Write-Host "Completed fork update"
 }


### PR DESCRIPTION
## PR

Include tags from upstream.
Release does not seem to add a lot of value.

In this change we're getting the tags, and pushing the new tags to the fork as well.

## Possible issue

I'm not sure how this will work when a tag is reused.

f.e. in the action/cache, the version tag: `v2` is always pointing to the latest minor version. I think we have to explicitly remove the previous tag, before you can push the tag.
https://github.com/philips-forks/cache/tags

## Related Issue

Closes #12 