### PR TITLE
Stop using unauthenticated git protocol, following best practices

### DIFF
--- a/github-calls.ps1
+++ b/github-calls.ps1
@@ -96,7 +96,7 @@ function GetParentInfo {
     }
 
     return [PSCustomObject]@{
-        parentUrl = $info.parent.git_url
+        parentUrl = $info.parent.html_url
         parentDefaultBranch = $info.parent.default_branch
     }
 


### PR DESCRIPTION
No more [unauthenticated Git](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git%5D) on the Git protocol side, unencrypted git:// offers no integrity or authentication, making it subject to tampering. We expect very few people are still using this protocol, especially given that you can’t push (it’s read-only on GitHub). 