### PR TITLE
Fix if statement in .github/workflows/update-workflow.yml

### DIFF
--- a/.github/workflows/update-workflow.yml
+++ b/.github/workflows/update-workflow.yml
@@ -21,7 +21,7 @@ jobs:
         github_app_token: ${{ steps.get-workflow-token.outputs.token }}
         PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
       run: |
-        if [ -n $github_app_token ]; then
+        if [[ -n $github_app_token ]]; then
           echo "token=$github_app_token" >> $GITHUB_OUTPUT
           echo "Using token from GitHub App"
         else


### PR DESCRIPTION
`[ -n $github_app_token ]` always evaluates to `true`

Possible solutions is to use `[[ ]]` or enclose `$github_app_token` into double quotes