### PR TITLE
Set output to GITHUB_OUTPUT env variable

### DIFF
--- a/.github/workflows/check-workflow.yml
+++ b/.github/workflows/check-workflow.yml
@@ -47,5 +47,5 @@ jobs:
         if ($null -ne $updateResult) {
           $reposWithUpdates = $updateResult[-1]
           Write-Host "Are there any updates available? [$($reposWithUpdates.Count -gt 0)]"
-          echo "::set-output name=update::$($reposWithUpdates.Count -gt 0)"
+          echo "name=update::$($reposWithUpdates.Count -gt 0)" >> $env:$GITHUB_OUTPUT
         }

--- a/.github/workflows/check-workflow.yml
+++ b/.github/workflows/check-workflow.yml
@@ -47,5 +47,5 @@ jobs:
         if ($null -ne $updateResult) {
           $reposWithUpdates = $updateResult[-1]
           Write-Host "Are there any updates available? [$($reposWithUpdates.Count -gt 0)]"
-          echo "name=update::$($reposWithUpdates.Count -gt 0)" >> $env:$GITHUB_OUTPUT
+          echo "update=$($reposWithUpdates.Count -gt 0)" >> $env:$GITHUB_OUTPUT
         }


### PR DESCRIPTION
I believe this to be the correct new format for GitHub Actions. No powershell guru, so something might be off.

References:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions?tool=powershell#example-masking-a-generated-output-within-a-single-job