### PR TITLE
Prevent issues with missing ContentType header in calls to GitHub API

### DIFF
--- a/github-calls.ps1
+++ b/github-calls.ps1
@@ -36,7 +36,7 @@ function CallWebRequest {
     try {
 
         $bodyContent = ($body | ConvertTo-Json) -replace '\\', '\'
-        $result = Invoke-WebRequest -Uri $url -Headers $Headers -Method $verbToUse -Body $bodyContent -ErrorAction Stop
+        $result = Invoke-WebRequest -Uri $url -Headers $Headers -Method $verbToUse -Body $bodyContent -ErrorAction Stop -ContentType "application/json"
         
         Write-Host "  StatusCode: $($result.StatusCode)"
         Write-Host "  RateLimit-Limit: $($result.Headers["X-RateLimit-Limit"])"

--- a/github-calls.ps1
+++ b/github-calls.ps1
@@ -79,12 +79,14 @@ function CallWebRequest {
 
     }
     catch {
-        Write-Host "Error calling api at [$url]:"
+        Write-Host "Error calling api at [$url]: $($_.Exception)"
         Write-Host "  StatusCode: $($_.Exception.Response.StatusCode)"
-        Write-Host "  RateLimit-Limit: $($_.Exception.Response.Headers.GetValues("X-RateLimit-Limit"))"
-        Write-Host "  RateLimit-Remaining: $($_.Exception.Response.Headers.GetValues("X-RateLimit-Remaining"))"
-        Write-Host "  RateLimit-Reset: $($_.Exception.Response.Headers.GetValues("X-RateLimit-Reset"))"
-        Write-Host "  RateLimit-Used: $($_.Exception.Response.Headers.GetValues("x-ratelimit-used"))"
+        if ($_.Exception.Response.Headers) {
+            Write-Host "  RateLimit-Limit: $($_.Exception.Response.Headers.GetValues("X-RateLimit-Limit"))"
+            Write-Host "  RateLimit-Remaining: $($_.Exception.Response.Headers.GetValues("X-RateLimit-Remaining"))"
+            Write-Host "  RateLimit-Reset: $($_.Exception.Response.Headers.GetValues("X-RateLimit-Reset"))"
+            Write-Host "  RateLimit-Used: $($_.Exception.Response.Headers.GetValues("x-ratelimit-used"))"
+        }
 
         $messageData = $_.ErrorDetails.Message | ConvertFrom-Json
         Write-Host "$($_.ErrorDetails.Message)"

--- a/readme.md
+++ b/readme.md
@@ -56,3 +56,12 @@ There are two ways to create this token:
 
 You can read more information about this in this [blogpost](https://devopsjournal.io/blog/2022/01/03/GitHub-Tokens).
 
+### GitHub App security scopes
+To use a GitHub App, create a repository variable called `use_github_app` and set its value to `true`. Then create an app with the following security scopes and install it at the org level with the repositories you want to handle updates for.
+
+** Scopes **
+- Actions: read & write (needed to be able to update files in the .github/workflows folder)
+- Contents: read & write (needed to be able to update the repo contents)
+- Issues: read & write (needed to create and close the issues to be able to notify you of updates)
+- Metadata: read only (default setting)
+

--- a/update-fork.ps1
+++ b/update-fork.ps1
@@ -56,7 +56,7 @@ function UpdateFork {
 
     # fetch the changes from the parent
     Write-Host "Fetching changes from parent repo"
-    git fetch github $parent.parentDefaultBranch --tags
+    git fetch github $parent.parentDefaultBranch --tags --force
 
     # make sure you are on the right branch
     Write-Host "Pulling all changes from the parent on branch [$($parent.parentDefaultBranch)]"
@@ -68,7 +68,7 @@ function UpdateFork {
 
     # push the changes back to your repo
     Write-Host "Pushing changes back to fork"
-    git push origin $parent.parentDefaultBranch --tags
+    git push origin $parent.parentDefaultBranch --tags --force
 
     Write-Host "Completed fork update"
 }


### PR DESCRIPTION
Addresses #114 which was:
1. not directly visible because of incomplete error handling
2. missing a (now required) ContentType header in the calls to the GitHub API. 

Also improves the docs to include the necessary scopes for the GitHub App.