### PR TITLE
fix: pin action dependencies to exact commit SHAs

### DIFF
--- a/.github/workflows/actions-dependencies.yml
+++ b/.github/workflows/actions-dependencies.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: jessehouwing/actions-dependency-submission@v1.0.10
+      - uses: jessehouwing/actions-dependency-submission@e978090f94fe0ef34cf078ed95bd24a9ff138df6 # v1.0.10
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes PinnedDependenciesID Scorecard alerts by pinning GitHub Actions to exact commit SHAs instead of version tags.

## Changes

- \ctions/checkout\: \6.0.2\ → \de0fac2e4500dabe0009e67214ff5f5447ce83dd\ (# v6.0.2)
- \jessehouwing/actions-dependency-submission\: \1.0.10\ → \978090f94fe0ef34cf078ed95bd24a9ff138df6\ (# v1.0.10)

## Resolves

- Closes code scanning alert #26
- Closes code scanning alert #30