### PR TITLE
fix: add least-privilege token permissions to workflows

### DIFF
--- a/.github/workflows/actions-dependencies.yml
+++ b/.github/workflows/actions-dependencies.yml
@@ -5,14 +5,15 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   submit-dependencies:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/check-workflow.yml
+++ b/.github/workflows/check-workflow.yml
@@ -7,6 +7,9 @@ on:
     - cron: 7 0 * * 1-5
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-for-updates:
     runs-on: ubuntu-latest

--- a/.github/workflows/new-issue-notification.yml
+++ b/.github/workflows/new-issue-notification.yml
@@ -2,12 +2,16 @@ name: Send notification on new issue
 on:
   issues:
     types: [opened]
-    
+
+permissions: {}
+
 jobs:
   # tag the team from the variables on any new issues created in this repo
   tag-a-user:
     if: ${{ vars.SEND_NOTIFICATION == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps: 
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0

--- a/.github/workflows/update-workflow.yml
+++ b/.github/workflows/update-workflow.yml
@@ -3,8 +3,7 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   update-fork:


### PR DESCRIPTION
## Summary

Fixes TokenPermissionsID Scorecard alerts by applying least-privilege `permissions` blocks to all affected workflow files.

## Changes

| File | Fix |
|------|-----|
| `actions-dependencies.yml` | Moved `contents: write` + `id-token: write` from workflow level to job level; added `permissions: {}` at workflow level |
| `update-workflow.yml` | Changed workflow-level `permissions: contents: read` to `permissions: {}`; job-level permissions already correct |
| `new-issue-notification.yml` | Added `permissions: {}` at workflow level; added `permissions: issues: write` at job level |
| `check-workflow.yml` | Added `permissions: contents: read` at workflow level |

## Resolves

- #29 – `actions-dependencies.yml` TokenPermissionsID alert
- #28 – `update-workflow.yml` TokenPermissionsID alert
- #8 – `new-issue-notification.yml` TokenPermissionsID alert
- #7 – `check-workflow.yml` TokenPermissionsID alert
- #6 – `update-workflow.yml` TokenPermissionsID alert