### PR TITLE
Fix Scorecard alerts: add SAST workflow, AGENTS.md, and branch protection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Copilot Instructions for github-fork-updater
+
+## Project Overview
+This repository is a PowerShell-based tool to check and update GitHub forks. It uses the GitHub API to find forks that are behind their upstream and creates issues or updates them automatically.
+
+## Tech Stack
+- **Language**: PowerShell
+- **Testing**: Pester (tests in `unittests/`)
+- **CI/CD**: GitHub Actions
+
+## Key Files
+- `updater.ps1` — main entry point
+- `update-fork.ps1` — fork update logic
+- `github-calls.ps1` — GitHub API call wrappers
+- `library.ps1` — shared utility functions
+- `unittests/updater.tests.ps1` — Pester unit tests
+
+## Conventions
+- Use PowerShell best practices and follow PSScriptAnalyzer recommendations
+- Keep GitHub API calls in `github-calls.ps1`
+- Add Pester tests for any new functions in `unittests/`
+- All workflows should pin action versions to a full SHA and include a version comment
+- Use `step-security/harden-runner` in all workflow jobs

--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -1,0 +1,44 @@
+name: PSScriptAnalyzer
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  psscriptanalyzer:
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1
+
+      - name: Run PSScriptAnalyzer
+        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f # v1.1
+        with:
+          path: ./
+          recurse: true
+          output: results.sarif
+          severity: warning
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        if: always()
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -35,7 +35,6 @@ jobs:
           path: ./
           recurse: true
           output: results.sarif
-          severity: warning
 
       - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+For AI agent instructions, see [.github/copilot-instructions.md](.github/copilot-instructions.md).


### PR DESCRIPTION
## Summary

Addresses several open OpenSSF Scorecard alerts and adds missing repo setup files.

### Changes

- **`AGENTS.md`** — Added pointer to `.github/copilot-instructions.md` for AI agents
- **`.github/copilot-instructions.md`** — Added project conventions for Copilot
- **`.github/workflows/psscriptanalyzer.yml`** — New SAST workflow using PSScriptAnalyzer, uploads SARIF to GitHub code scanning (addresses Scorecard **SAST** alert #13)

### Repo-level changes (already applied)
- Created **branch ruleset** "Protect main branch" on `main`:
  - Requires a PR before merging (addresses Scorecard **BranchProtection** #1 and partially **CodeReview** #11)
  - Required status check: `test-direct` (addresses Scorecard **CITests** #9)
  - `rajbos` bypass enabled
  - `do_not_enforce_on_create` enabled so simple README-only PRs aren't blocked

### Remaining alerts (not automatable)
- **CIIBestPractices (#10)**: Requires manually applying for an OpenSSF badge at https://bestpractices.coreinfrastructure.org/
- **Fuzzing (#12)**: Not practical for a PowerShell script repo
- **CodeReview (#11)**: Scorecard expects ≥1 required reviewer; with a solo repo this will remain partial