### PR TITLE
chore: configure Dependabot grouped updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,16 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /.devcontainer
     schedule:
       interval: daily
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why

With multiple Action and Docker dependencies updated separately, each run produced several individual PRs -- today we merged 4 in a row. Grouping updates by ecosystem reduces that noise to a single PR per ecosystem per schedule run.

## What changed

Added a `groups` block to each ecosystem entry in `.github/dependabot.yml`:

- **github-actions** -- all GitHub Actions version bumps are batched into one PR per monthly run.
- **docker** -- all Docker image bumps in `.devcontainer` are batched into one PR per daily run.

No schedule intervals or other settings were changed.